### PR TITLE
Support for generic network

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ of these services, you likely would not use a docker version of them in producti
    3. `docker network create st-mysql-56`
    4. `docker network create st-postgres-95`
    5. `docker network create st-redis-32`
+   6. `docker network create st-internal`
 5. Execute `docker-compose up --build`
 - If you're in a Windows environment, then perform the following if your build fails:
    1. Kill, and optionally disable, the `World Wide Web Publishing Service`.

--- a/docker/data-source-services/network-creation.sh
+++ b/docker/data-source-services/network-creation.sh
@@ -1,4 +1,5 @@
 echo "Creating container networks:\n"
+docker network create st-internal
 docker network create nginx-proxy
 docker network create st-mariadb-102
 docker network create st-mysql-56


### PR DESCRIPTION
While setting up a new project, I ran into

```
➜  docker git:(master) ✗ docker network create xxxx-internal
Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network
```

Apparently from https://stackoverflow.com/a/53838883/455008, this is because Docker caps out at 30 networks. After that and it refuses to work. I thought about deleting old/legacy projects, but that doesn't help things like Jenkins and onboarding.

I think making an internal network at the dev-ops level and just using that network to pivot between php/nginx could work fine. I don't see any immediate concerns for this plan, so pending merge I can cut another release/tag.

So new projects (instead of making their own network) can just define this network as external and use it.

```
networks:
  st-internal:
    external:
      name: st-internal
```