### PR TITLE
docs: retire old network names + add missing 10.4 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ of these services, you likely would not use a docker version of them in producti
 3. `cd ./docker/data-source-services/`
 4. Execute `./network-creation.sh`
 - If this fails, then manual configuration is necessary before compilation. Perform the following:
-   1. `docker network create nginx-proxy`
+   1. `docker network create st-internal`
 5. Execute `docker-compose up --build`
 - If you're in a Windows environment, then perform the following if your build fails:
    1. Kill, and optionally disable, the `World Wide Web Publishing Service`.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ of these services, you likely would not use a docker version of them in producti
 4. Execute `./network-creation.sh`
 - If this fails, then manual configuration is necessary before compilation. Perform the following:
    1. `docker network create nginx-proxy`
-   2. `docker network create st-mariadb-102`
-   3. `docker network create st-postgres-95`
-   4. `docker network create st-redis-32`
-   5. `docker network create st-internal`
 5. Execute `docker-compose up --build`
 - If you're in a Windows environment, then perform the following if your build fails:
    1. Kill, and optionally disable, the `World Wide Web Publishing Service`.
@@ -49,6 +45,7 @@ If the optional tools are launched, you can find phpMyAdmin at: localhost:8080
   * It supports the following databases...
     * mariadb102
     * mariadb103
+    * mariadb104
 
 ## Examples
 Inside the `examples` folder you will find example Docker configurations for


### PR DESCRIPTION
* The old network names aren't used (unless your project uses them) and if so, you know that since your scripts/ci do it.
* New toads should not have these networks filling up the 30 limit if they are unused.
* Added missing 10.4 note in readme