### PR TITLE
DB Migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ popular frameworks like Laravel and Yii2.
 The examples make the assumption that any domain used for local development is
 already added to the `/etc/hosts` file. You can edit to add `127.0.0.1 domain.docker`.
 
+## Scripts
+Inside the `scripts` folder you will find one-off scripts to help with tasks.
+
+ * `db_migrate.sh` - Helps migrate databases between versions of mysql.
+
 ## Docs
  * [Setting up Nginx-Proxy](docs/nginx-proxy/README.md)
  * [Setting up PHP Testing in PHPStorm](docs/phpstorm-docker/README.md)

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -13,40 +13,40 @@ DB_IMPORT_FLAGS=''
 
 # Determine DB
 echo "Welcome to the SDIT DB Migrator (mysql/postgres) $NEWLINE"
-read -rp "Select (mysql|postgres):" DBMODE
+read -rp "Select (mysql|postgres):" DB_MODE
 read -rp "Enter (FROM) port number:" DB_PORT
 read -rp "Enter (FROM) database name: " DB_NAME
 read -rp "Enter (TO) port number:" DB_TO_PORT
 read -rp "Enter (TO) database name: " DB_TO_NAME
 
-case $DBMODE in
+case $DB_MODE in
+    mysql|maria|mariadb)
+        DB_BINARY_NAME='mysql'
 
-  mysql|maria|mariadb)
-    DB_BINARY_NAME='mysql'
+        # Attempt to connect to DB (FROM and TO).
+        if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_PORT}" -e "use ${DB_NAME}"; then
+            echo "Database (FROM) could not be connected ($DB_NAME, $DB_PORT). Aborting...$NEWLINE"
+            exit 1
+        fi
 
-    # Attempt to connect to DB (FROM and TO).
-    if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_PORT}" -e "use ${DB_NAME}"; then
-       echo "Database (FROM) could not be connected ($DB_NAME, $DB_PORT). Aborting...$NEWLINE"
-       exit 1;
-    fi
+        if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_TO_PORT}" -e "use ${DB_TO_NAME}"; then
+            echo "Database (TO) could not be connected ($DB_TO_NAME, $DB_TO_PORT). Aborting...$NEWLINE"
+            exit 1
+        fi
 
-    if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_TO_PORT}" -e "use ${DB_TO_NAME}"; then
-       echo "Database (TO) could not be connected ($DB_TO_NAME, $DB_TO_PORT). Aborting...$NEWLINE"
-       exit 1;
-    fi
-
-    echo -n "Copying...! $NEWLINE"
-    mysqldump $DB_EXPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_PORT}" "${DB_NAME}" | mysql $DB_IMPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_TO_PORT}" "${DB_TO_NAME}"
-    echo -n "Copied...! $NEWLINE"
+        echo -n "Copying...! $NEWLINE"
+        mysqldump $DB_EXPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_PORT}" "${DB_NAME}" | mysql $DB_IMPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_TO_PORT}" "${DB_TO_NAME}"
+        echo -n "Copied...! $NEWLINE"
     ;;
 
-  pg|postgres)
-    echo -n "Postgres support is still in progress. Aborting...$NEWLINE"
+    pg | postgres)
+        echo -n "Postgres support is still in progress. Aborting...$NEWLINE"
     ;;
 
-  *)
-    echo -n "This selection is unknown. Aborting...$NEWLINE"
-    exit 1;
+    *)
+        echo -n "This selection is unknown. Aborting...$NEWLINE"
+        exit 1
+    ;;
 esac
 
-exit 0;
+exit 0

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Variable Setup
+NEWLINE=$'\n'
+
+DB_BINARY_NAME=''
+DB_PORT=''
+DB_HOST='127.0.0.1'
+DB_USER='root'
+DB_PASS='root'
+DB_EXPORT_FLAGS='--column-statistics=0 --quick --hex-blob --single-transaction'
+DB_IMPORT_FLAGS=''
+
+# Determine DB
+echo "Welcome to the SDIT DB Migrator (mysql/postgres) $NEWLINE"
+read -rp "Select (mysql|postgres):" DBMODE
+read -rp "Enter (FROM) port number:" DB_PORT
+read -rp "Enter (FROM) database name: " DB_NAME
+read -rp "Enter (TO) port number:" DB_TO_PORT
+read -rp "Enter (TO) database name: " DB_TO_NAME
+
+case $DBMODE in
+
+  mysql|maria|mariadb)
+    DB_BINARY_NAME='mysql'
+
+    # Attempt to connect to DB (FROM and TO).
+    if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_PORT}" -e "use ${DB_NAME}"; then
+       echo "Database (FROM) could not be connected ($DB_NAME, $DB_PORT). Aborting...$NEWLINE"
+       exit 1;
+    fi
+
+    if ! $DB_BINARY_NAME --host="${DB_HOST}" --user="${DB_USER}" --password="${DB_PASS}" --port="${DB_TO_PORT}" -e "use ${DB_TO_NAME}"; then
+       echo "Database (TO) could not be connected ($DB_TO_NAME, $DB_TO_PORT). Aborting...$NEWLINE"
+       exit 1;
+    fi
+
+    echo -n "Copying...! $NEWLINE"
+    mysqldump $DB_EXPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_PORT}" "${DB_NAME}" | mysql $DB_IMPORT_FLAGS --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" --port="${DB_TO_PORT}" "${DB_TO_NAME}"
+    echo -n "Copied...! $NEWLINE"
+    ;;
+
+  pg|postgres)
+    echo -n "Postgres support is still in progress. Aborting...$NEWLINE"
+    ;;
+
+  *)
+    echo -n "This selection is unknown. Aborting...$NEWLINE"
+    exit 1;
+esac
+
+exit 0;

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -8,7 +8,7 @@ DB_PORT=''
 DB_HOST='127.0.0.1'
 DB_USER='root'
 DB_PASS='root'
-DB_EXPORT_FLAGS='--column-statistics=0 --quick --hex-blob --single-transaction'
+DB_EXPORT_FLAGS='--routines --column-statistics=0 --quick --hex-blob --single-transaction'
 DB_IMPORT_FLAGS=''
 
 # Determine DB


### PR DESCRIPTION
```
➜  DevopsToolKit git:(db-migrate) ✗ ./scripts/db_migrate.sh
Welcome to the SDIT DB Migrator (mysql/postgres) 

Select (mysql|postgres):mysql
Enter (FROM) port number:33101
Enter (FROM) database name: redacted
Enter (TO) port number:33103
Enter (TO) database name: redacted
Copying...! 
Copied...! 
➜  DevopsToolKit git:(db-migrate) ✗ 
```

 * TLDR - We are upgrading database versions for projects more often and its becoming quite a pain to restore a local db by exporting/importing etc. 