### PR TITLE
SIP-39 - Laravel PHP8 Template Upgrade + Node 14

### DIFF
--- a/examples/laravel/Dockerfile
+++ b/examples/laravel/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.0-fpm
 
 # System dependencies needed
 RUN apt-get update && apt-get install -y \
@@ -43,7 +43,7 @@ WORKDIR /code
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # Node: We should use another container for this, since we are mixing PHP and Node
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs
 
 # Yarn: Installing

--- a/examples/laravel/config/php.ini
+++ b/examples/laravel/config/php.ini
@@ -11,14 +11,13 @@ upload_max_filesize = 64M
 post_max_size = 64M
 
 [xdebug]
-xdebug.remote_enable = 1
-xdebug.coverage_enable = 1
+xdebug.mode = debug
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9000
+xdebug.discover_client_host = no
+xdebug.start_with_request = yes
 xdebug.idekey = xdebug
-xdebug.remote_port = 9000
-xdebug.remote_autostart = 1
-xdebug.remote_host = host.docker.internal
-xdebug.remote_connect_back = 0
+xdebug.max_nesting_level = 256
 xdebug.var_display_max_depth = 5
 xdebug.var_display_max_children = 256
 xdebug.var_display_max_data = 1024
-xdebug.max_nesting_level = 256

--- a/examples/yii2/config/php.ini
+++ b/examples/yii2/config/php.ini
@@ -11,14 +11,13 @@ upload_max_filesize = 64M
 post_max_size = 64M
 
 [xdebug]
-xdebug.remote_enable = 1
-xdebug.coverage_enable = 1
+xdebug.mode = debug
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9000
+xdebug.discover_client_host = no
+xdebug.start_with_request = yes
 xdebug.idekey = xdebug
-xdebug.remote_port = 9000
-xdebug.remote_autostart = 1
-xdebug.remote_host = host.docker.internal
-xdebug.remote_connect_back = 0
+xdebug.max_nesting_level = 256
 xdebug.var_display_max_depth = 5
 xdebug.var_display_max_children = 256
 xdebug.var_display_max_data = 1024
-xdebug.max_nesting_level = 256


### PR DESCRIPTION
So I upgraded to PHP8 / Node14 for the template and first pain point was just the emitting of notices/warnings/etc.

You'll get this:

```
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.coverage_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.coverage_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.remote_autostart' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_autostart (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.remote_connect_back' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_connect_back (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.remote_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.remote_host' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_host (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
[10-Dec-2020 14:05:20 UTC] Xdebug: [Config] The setting 'xdebug.remote_port' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_port (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)
```

So this diff also includes the removal of xdebug2.x. I figure this is fine, because this is the template so a new project using the template will have no existing users - thus the build of the image will include xdebug3. For existing projects we probably need to live with both xdebug2 / xdebug3 unless we force all to upgrade on one day.

Once we smoke test this (outside of a build) we might want to adapt the ini if the change to logging is to verbose.