### PR TITLE
Remove references to removed networks

### DIFF
--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./proxy_increase.conf:/etc/nginx/proxy.conf
     networks:
-     - nginx-proxy
      - st-internal
   postgres95:
     image: postgres:9.5
@@ -26,7 +25,6 @@ services:
       - POSTGRES_USER=postgres_user
       - POSTGRES_PASSWORD=postgres_pass
     networks:
-      - st-postgres-95
       - st-internal
     command: "postgres
                 -c logging_collector='on'
@@ -93,7 +91,6 @@ services:
       - MYSQL_USER=mariadb_user
       - MYSQL_PASSWORD=mariadb_pass
     networks:
-      - st-mariadb-102
       - st-internal
   redis32:
     image: redis:3.2-alpine
@@ -102,21 +99,8 @@ services:
     ports:
       - "6332:6379"
     networks:
-      - st-redis-32
       - st-internal
 networks:
-    nginx-proxy:
-        external:
-            name: nginx-proxy
-    st-postgres-95:
-        external:
-            name: st-postgres-95
     st-internal:
         external:
             name: st-internal
-    st-mariadb-102:
-        external:
-            name: st-mariadb-102
-    st-redis-32:
-        external:
-            name: st-redis-32

--- a/docs/phpstorm-docker/README.md
+++ b/docs/phpstorm-docker/README.md
@@ -39,17 +39,7 @@ services:
         volumes:
             - ../:/code:delegated
         networks:
-            - project-internal
-            - st-mariadb-101
-            - st-redis-32
-networks:
-    project-internal:
-    st-redis-32:
-        external:
-            name: st-redis-32
-    st-mariadb-101:
-        external:
-            name: st-mariadb-101
+            - st-internal
 ```
 
 As you can see, it is a subset of the compose file. It only includes a clone of 


### PR DESCRIPTION
This resolves a series of errors that happen when `docker-compose up` is executed.

Example:
```
--- docker/data-source-services ‹master› » docker-compose up --build -d
ERROR: Network nginx-proxy declared as external, but could not be found. Please create the network manually using `docker network create nginx-proxy` and try again.
```