### PR TITLE
fix: Change network name for deprecated yml configuration

### DIFF
--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -86,5 +86,4 @@ services:
       - st-internal
 networks:
     st-internal:
-        external:
-            name: st-internal
+        name: st-internal


### PR DESCRIPTION
I get a warning on new versions of Docker about `network.external.name` being deprecated in favor of `network.name`.