### PR TITLE
JEST-226 build: lock docker to composer2

### DIFF
--- a/examples/laravel/Dockerfile
+++ b/examples/laravel/Dockerfile
@@ -40,7 +40,7 @@ COPY ./config/php.ini /usr/local/etc/php/
 WORKDIR /code
 
 # Make sure we're installing what we think we're installing!
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 # Node: We should use another container for this, since we are mixing PHP and Node
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \


### PR DESCRIPTION
Figured this would be good to put into our templates. Since the `latest` tag from docker is bugged in so many ways.

https://vsupalov.com/docker-latest-tag/
https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375
https://blog.container-solutions.com/docker-latest-confusion
