### PR TITLE
docs: deprecate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+_Deprecated. All future changelogs in [GitHub Release](https://github.com/sourcetoad/DevopsToolKit/releases)_
+
+---
+
 # v1.3.0 (November 9, 2020)
 * Retire non `st-internal` network names (not yet removed).
 * Remove outdated python and upsource documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-_Deprecated. All future changelogs in [GitHub Release](https://github.com/sourcetoad/DevopsToolKit/releases)_
+_Deprecated. All future changelogs in [GitHub Releases](https://github.com/sourcetoad/DevopsToolKit/releases)._
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-_Deprecated. All future changelogs in [GitHub Releases](https://github.com/sourcetoad/DevopsToolKit/releases)._
+# Deprecated
+_All future changelogs in [GitHub Releases](https://github.com/sourcetoad/DevopsToolKit/releases)._
 
 ---
 


### PR DESCRIPTION
In favor for more automation for our open source offerings with less burden of making releases or keeping track of them with a manually generated changelog file.

If anything, we will start an `UPGRADE.md` used for breaking changes.

Context - https://github.com/sourcetoad/DevopsToolKit/pull/33