### PR TITLE
build: redis 6.2

### DIFF
--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -60,12 +60,12 @@ services:
       - MYSQL_PASSWORD=mariadb_pass
     networks:
       - st-internal
-  redis32:
-    image: redis:3.2-alpine
+  redis62:
+    image: redis:6.2-alpine
     command: redis-server --appendonly yes
     container_name: sourcetoad_redis32
     ports:
-      - "6332:6379"
+      - "6362:6379"
     networks:
       - st-internal
 networks:


### PR DESCRIPTION
Confirmed no active projects use older 3.2 redis.