### PR TITLE
feat: add maria 10.11, drop 10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ cd ./devop-tools/docker/data-source-services && docker-compose up --build -d
 ## phpMyAdmin
 If the optional tools are launched, you can find phpMyAdmin at: localhost:8080
 * It supports the following databases...
-  * mariadb103 (deprecated)
-  * mariadb104
-  * mariadb105
-  * mariadb106
+  * mariadb104 (deprecated)
+  * mariadb105 (deprecated)
+  * mariadb106 (lts)
+  * mariadb1011 (lts)
 
 ## Examples
 Inside the `examples` folder you will find example Docker configurations for

--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -16,6 +16,17 @@ services:
       - ./proxy_increase.conf:/etc/nginx/proxy.conf
     networks:
      - st-internal
+  mariadb1011:
+    image: mariadb:10.11
+    container_name: sourcetoad_mariadb1011
+    ports:
+      - "33111:3311"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=mariadb_user
+      - MYSQL_PASSWORD=mariadb_pass
+    networks:
+      - st-internal
   mariadb106:
     image: mariadb:10.6
     container_name: sourcetoad_mariadb106
@@ -43,17 +54,6 @@ services:
     container_name: sourcetoad_mariadb104
     ports:
       - "33104:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=mariadb_user
-      - MYSQL_PASSWORD=mariadb_pass
-    networks:
-      - st-internal
-  mariadb103:
-    image: mariadb:10.3
-    container_name: sourcetoad_mariadb103
-    ports:
-      - "33103:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_USER=mariadb_user

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - st-internal
     environment:
-      PMA_HOSTS: mariadb103,mariadb104,mariadb105,mariadb106
+      PMA_HOSTS: mariadb104,mariadb105,mariadb106,mariadb1011
       PMA_USER: root
       PMA_PASSWORD: root
 networks:


### PR DESCRIPTION
Going forward we are going to only track LTS versions for Maria. So that means 10.4/10.5 are deprecated and the remaining few projects on it will be migrated to 10.6/10.11.