### PR TITLE
build: support external networks and labeled external network

### DIFF
--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -2,7 +2,7 @@
 # Everything ahead of the last two digits are standard for the given service
 #
 # Network name is st-{service name}-{service MAJOR.MINOR}
-version: '2'
+version: '3.8'
 services:
   nginxproxy:
 # Enable nginx debug and increase output verbosity

--- a/docker/data-source-services/network-creation.sh
+++ b/docker/data-source-services/network-creation.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo "Creating container networks:"
-docker network create st-internal
+docker network create st-internal --label "com.docker.compose.network=default"

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.8'
 services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest


### PR DESCRIPTION
Version `2` does not properly handle external/name networks. So our line was misleading in referring to an external network. 

There is an active, unclosed bug in docker https://github.com/docker/compose/issues/10797 which in the latest update (4.21.1 (114176)) has caused our containers to fail booting.

```
network st-internal was found but has incorrect label com.docker.compose.network set to ""
```

I'm guessing we'll get a hotfix since it seems unlikely that we have to track or workaround this. So if your project fails you might have to remake our network via:

```
stop docker
docker network rm -f st-internal
docker network create st-internal --label "com.docker.compose.network=default
```

Bring projects up again. If they fail with:

```
Error response from daemon: network 9e5f253c7227c37b38b06e05464af10fc511d543dfc6ee518abe615df0142fe4 not found
```

Run with `--force-recreate` to re-establish path to new network without data loss.