### PR TITLE
Remove MariaDB 10.4 & 10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ cd ./devop-tools/docker/data-source-services && docker-compose up --build -d
 ## phpMyAdmin
 If the optional tools are launched, you can find phpMyAdmin at: localhost:8080
 * It supports the following databases...
-  * mariadb104 (deprecated)
-  * mariadb105 (deprecated)
   * mariadb106 (lts)
   * mariadb1011 (lts)
 

--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -38,28 +38,6 @@ services:
       - MYSQL_PASSWORD=mariadb_pass
     networks:
       - st-internal
-  mariadb105:
-    image: mariadb:10.5
-    container_name: sourcetoad_mariadb105
-    ports:
-      - "33105:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=mariadb_user
-      - MYSQL_PASSWORD=mariadb_pass
-    networks:
-      - st-internal
-  mariadb104:
-    image: mariadb:10.4
-    container_name: sourcetoad_mariadb104
-    ports:
-      - "33104:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=mariadb_user
-      - MYSQL_PASSWORD=mariadb_pass
-    networks:
-      - st-internal
 networks:
     st-internal:
         external: true

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - st-internal
     environment:
-      PMA_HOSTS: mariadb104,mariadb105,mariadb106,mariadb1011
+      PMA_HOSTS: mariadb106,mariadb1011
       PMA_USER: root
       PMA_PASSWORD: root
 networks:


### PR DESCRIPTION
As we've learned with newer projects and requirements. A few projects have inlined their DB requirements due to "reasons".

So we've found over time - more and more databases leave this project. Its true main purpose has been just reversing HTTP ports so projects don't collide.

So we retire the non-lts MariaDB versions here. The LTS will be the only ones that remain or are tracked.