### PR TITLE
Extend git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,55 @@ Inside the `scripts` folder you will find one-off scripts to help with tasks.
 
 * `db_migrate.sh` - Helps migrate databases between versions of mysql.
 
+## Git Scripts
+Custom scripts that extend Git functionality, to streamline the process of tracking tickets and managing releases
+
+### Installation
+Either copy the scripts into your `PATH` or run the following command to add the scripts to your `PATH`
+```shell
+scripts/link-git-commands.sh
+```
+* This will link git scripts to a `bin` folder in your home directory. If you do not have a `bin` folder, it will create one for you.
+
+`git-tickets`
+---------
+This command is used to get the tickets since staging was was last updated. By default it does not update the branches
+
+```shell
+git tickets [options] [arguments]
+``` 
+
+| Options  | Description                                                     | Default | Any of |
+|----------|-----------------------------------------------------------------|---------|--------|
+| --update | Update the specified branches from the remote before comparison |         |        |
+
+| Arguments | Description                          | Default | Any of     |
+|-----------|--------------------------------------|---------|------------|
+| branch 1  | the target branch that is up to date | master  | any branch |
+| branch 2  | the branch that is behind            | staging | any branch |
+
+### Example
+```shell
+  git tickets --update master staging
+```
+
+`git-make-release`
+---------
+This command automates the process of preparing a new software release. It creates a release branch from the current branch, increments the version number, updates the `CHANGELOG.md`
+
+```shell
+    git make-release [options]
+```
+
+| Options  | Description                                               | Default |
+|----------|-----------------------------------------------------------|---------|
+| --dry    | Perform a dry run without any changes to branches or tags | N/A     |
+
+### Example
+```shell
+git make-release --dry
+```
+
 ## Docs
 * [Setting up Nginx-Proxy](docs/nginx-proxy/README.md)
 * [Setting up PHP Testing in PhpStorm](docs/phpstorm-docker/README.md)

--- a/scripts/add-bin-dir.sh
+++ b/scripts/add-bin-dir.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Define the bin directory path
+BIN_DIR="$HOME/bin"
+
+# Create the bin directory if it doesn't exist
+if [ ! -d "$BIN_DIR" ]; then
+    mkdir -p "$BIN_DIR"
+    echo "Created $BIN_DIR"
+else
+    echo "$BIN_DIR already exists."
+fi
+
+# add bin to the PATH only if it's not already there
+update_path() {
+    local profile=$1
+    if ! grep -q "PATH=.*:$BIN_DIR" "$profile" && ! grep -q "PATH=$BIN_DIR:.*" "$profile"; then
+        echo "export PATH=\"\$PATH:$BIN_DIR\"" >> "$profile"
+        echo "Added $BIN_DIR to PATH in $profile"
+    else
+        echo "$BIN_DIR is already in the PATH in $profile"
+    fi
+}
+
+# Check for zsh or bash and their respective files
+if [ -n "$ZSH_VERSION" ]; then
+    if [ -f "$HOME/.zshrc" ]; then
+        update_path "$HOME/.zshrc"
+    fi
+elif [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bash_profile" ]; then
+        update_path "$HOME/.bash_profile"
+    elif [ -f "$HOME/.bashrc" ]; then
+        update_path "$HOME/.bashrc"
+    elif [ -f "$HOME/.profile" ]; then
+        update_path "$HOME/.profile"
+    fi
+else
+    echo "Unrecognized shell or profile file not found."
+fi
+
+# Apply the changes by sourcing the profile files
+if [ -n "$ZSH_VERSION" ] && [ -f "$HOME/.zshrc" ]; then
+    source "$HOME/.zshrc"
+elif [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bash_profile" ]; then
+        source "$HOME/.bash_profile"
+    elif [ -f "$HOME/.bashrc" ]; then
+        source "$HOME/.bashrc"
+    elif [ -f "$HOME/.profile" ]; then
+        source "$HOME/.profile"
+    fi
+fi

--- a/scripts/git-make-release
+++ b/scripts/git-make-release
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Prompt for the version number
+prompt_for_version() {
+  read -p "Enter the version number (default: $1): " version
+  echo "${version:-$1}" # Return the entered version number or the default if none was entered
+}
+
+# Increment version number
+increment_version() {
+  local IFS='.'
+  read -a version_parts <<< "$1"
+  # Increment the minor version and reset patch version
+  local next_version="${version_parts[0]}.$((version_parts[1] + 1)).0"
+
+  # Prompt for the version number, using the next version as the default
+  read -p "Enter the version number (default: $next_version): " version
+  echo "${version:-$next_version}" # Return the entered version number or the default if none was entered
+}
+
+# Get the latest version tag
+get_latest_version() {
+  git describe --tags "$(git rev-list --tags --max-count=1)"
+}
+
+# Prepend the tickets to the CHANGELOG.md
+prepend_to_changelog() {
+  local version=$1
+  local tickets=$2
+  local date=$(date +"%b %d, %Y")
+  local changelog="CHANGELOG.md"
+
+  # Create a backup of the CHANGELOG.md
+  cp "$changelog" "$changelog.bak"
+
+  # Prepend the new content to the CHANGELOG.md
+  {
+    echo "# v$version ($date)"
+    for ticket in $tickets; do
+      echo "* $ticket - "
+    done
+    echo ""
+    cat "$changelog.bak"
+  } > "$changelog"
+
+  rm "$changelog.bak"
+}
+
+# Check if the --dry flag is set
+DRY_RUN=false
+if [ "$1" == "--dry" ]; then
+  DRY_RUN=true
+fi
+
+# Get the latest tag and suggest the next version number
+LATEST_TAG=$(get_latest_version)
+NEXT_VERSION=$(increment_version ${LATEST_TAG#v}) # Assuming the tag is in the 'v1.2.3' format
+
+if $DRY_RUN; then
+  # Perform a dry run
+  echo "This is a dry run. The release branch will not be created."
+  echo "The next version number would be: ${NEXT_VERSION}"
+  git tickets | grep -Eo '(\w+)-([0-9]+)'
+else
+  # Perform the actual release process
+  # Capture the output of git-tickets
+  TICKETS_OUTPUT=$(git tickets --update)
+
+  # Use grep to filter the output
+  TICKET_IDS=$(echo "$TICKETS_OUTPUT" | grep -Eo '(\w+)-([0-9]+)')
+
+  # Prepend the tickets to the CHANGELOG.md
+  prepend_to_changelog "$NEXT_VERSION" "$TICKET_IDS"
+
+  # Checkout a new branch with the pattern release-###
+  git checkout -b "release-${NEXT_VERSION}"
+
+  # Add the CHANGELOG.md to the staging area
+  git add CHANGELOG.md
+
+  echo "Tickets to be included in this release:"
+  echo "$TICKET_IDS"
+fi

--- a/scripts/git-tickets
+++ b/scripts/git-tickets
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Prompt for a branch name with a default
+prompt_for_branch() {
+  read -p "Enter the name of the $1 branch (default: $2): " branch
+  echo "${branch:-$2}" # Return the entered branch name or the default if none was entered
+}
+
+# Check for --update flag
+UPDATE_BRANCHES=false
+for arg in "$@"; do
+  if [ "$arg" == "--update" ]; then
+    UPDATE_BRANCHES=true
+    break
+  fi
+done
+
+# Prompt for the first branch name if not provided
+if [ -z "$1" ] || [ "$1" == "--update" ]; then
+  BRANCH1=$(prompt_for_branch "first" "master")
+else
+  BRANCH1="$1"
+fi
+
+# Prompt for the second branch name if not provided
+if [ -z "$2" ] || [ "$2" == "--update" ]; then
+  BRANCH2=$(prompt_for_branch "second" "staging")
+else
+  BRANCH2="$2"
+fi
+# Function to update or create temporary branches
+process_branch() {
+  local branch_name=$1
+  local temp_branch="temp_${branch_name}_$$"
+  if $UPDATE_BRANCHES; then
+    git checkout $branch_name &> /dev/null
+    git pull origin $branch_name &> /dev/null
+    echo "$branch_name"
+  else
+    git fetch origin $branch_name:$temp_branch &> /dev/null
+    echo $temp_branch
+  fi
+}
+
+# Process the first branch
+BRANCH1=$(process_branch $BRANCH1)
+
+# Process the second branch
+BRANCH2=$(process_branch $BRANCH2)
+
+# If not updating branches, use the temporary branches for log
+if ! $UPDATE_BRANCHES; then
+  # Run the git log command and process the output on temporary branches
+  git log $BRANCH2..$BRANCH1 --oneline --no-merges | grep -Eio "(\w+)-([0-9]+)" | tr '[:lower:]' '[:upper:]' | sort -u
+
+  # Delete the temporary branches
+  git branch -D $BRANCH1 &> /dev/null
+  git branch -D $BRANCH2 &> /dev/null
+  git status;
+else
+  # Run the git log command and process the output on updated branches
+  git log $BRANCH2..$BRANCH1 --oneline --no-merges | grep -Eio "(\w+)-([0-9]+)" | tr '[:lower:]' '[:upper:]' | sort -u
+
+  # Checkout to the first branch (assumed to be 'master')
+  git checkout $BRANCH1 &> /dev/null
+  git status
+fi

--- a/scripts/link-git-commands.sh
+++ b/scripts/link-git-commands.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Path to the 'add-bin-dir' script, assuming it's in the same directory as this script
+ADD_BIN_DIR_SCRIPT="$SCRIPT_DIR/add-bin-dir.sh"
+
+# Call the 'add-bin-dir' script to ensure 'bin' directory is created and in the PATH
+/bin/bash "$ADD_BIN_DIR_SCRIPT"
+
+# Define the directory where your 'git-' scripts are located, assuming the current directory
+GIT_SCRIPTS_DIR="$SCRIPT_DIR"
+
+# The 'bin' directory path
+BIN_DIR="$HOME/bin"
+
+# Check if the --dry flag is set
+DRY_RUN=false
+if [ "$1" == "--dry" ]; then
+  DRY_RUN=true
+fi
+
+# Function to create symlinks or simulate creating them
+create_symlink() {
+    local script=$1
+    local symlink_path="$BIN_DIR/$(basename "$script")"
+    if [ -x "$script" ]; then  # Check if the script file is executable
+        if $DRY_RUN; then
+            echo "Dry run: Would create symlink for $(basename "$script")"
+        else
+            ln -s "$script" "$symlink_path"
+            echo "Symlink created for $(basename "$script")"
+        fi
+    else
+        echo "Skipped $(basename "$script") as it is not executable."
+    fi
+}
+
+# Now create symlinks for all 'git-' scripts in the 'bin' directory
+for script in "$GIT_SCRIPTS_DIR"/git-*; do
+    if [[ -f "$script" ]]; then
+        create_symlink "$script"
+    fi
+done
+
+# Let the user know the operation is complete
+if $DRY_RUN; then
+    echo "Dry run complete. No symlinks were actually created."
+else
+    echo "All executable Git scripts have been symlinked to $BIN_DIR."
+fi


### PR DESCRIPTION
This will help with the steps defined in our team's project release guide, I believe Iceman also uses a similar process. The goal is to reduce the manual steps needed to make a release.

This PR includes scripts for creating a `bin` directory in the user's home directory and adding it to the `$PATH` if it doesn't exist, as well as a script to symlink `git-` scripts to the `bin` dir. 

The two git scripts extend the `git` command to add `tickets` and `make-release`. The former gets the new tickets from the first branch that are not in the second branch. The `make-release` will create a new branch and prepend the ticket information in the `CHANGELOG.md`. 