### PR TITLE
JEST-1246 Fix lint warnings on DevopsToolKit

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master


### PR DESCRIPTION
# GitHub Actions Update

Updating the github actions to use newer node version by default to get rid of warnings of older Node versions being used.

## Changes

- actions/checkout: v2 -> v4
- github/super-linter/slim: v4 -> v5
