### PR TITLE
build: move order of db from newest to oldest

### DIFF
--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - st-internal
     environment:
-      PMA_HOSTS: mariadb106,mariadb1011
+      PMA_HOSTS: mariadb1011,mariadb106
       PMA_USER: root
       PMA_PASSWORD: root
 networks:


### PR DESCRIPTION
This will make 10.11 the default, with a click to move to 10.6. That seems preferred. We default to the newest.