### PR TITLE
build: remove 'version' property

### DIFF
--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -3,7 +3,6 @@
 #
 # Network name is st-{service name}-{service MAJOR.MINOR}
 ---
-version: '3.8'
 services:
   nginxproxy:
 # Enable nginx debug and increase output verbosity

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   mailpit:
     image: axllent/mailpit:latest


### PR DESCRIPTION
With `docker-compose` gone now - nothing reads `version` anymore. Thus we get warnings.

```
WARN[0000] DevopsToolKit/docker/data-source-services/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

I'm sure if someone hasn't taken the upgrade that removes `docker-compose` for `docker compose` - they will soon.