### PR TITLE
Make hop pass through error

### DIFF
--- a/bin/hop
+++ b/bin/hop
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 HOP_PATH=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 TOOLKIT_PATH=$(dirname "$HOP_PATH")
 


### PR DESCRIPTION
Currently if a hop command fails, it will exit with success rather than the original error code. This isn't an issue in most cases since we don't use it in scripts or CI, but it's still helpful to pass any error codes up so multiple commands run with `&&` don't continue down the chain.