### PR TITLE
MariaDB 11.4 - LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ _For managing MySQL/MariaDB databases visually._
 
 * Viewable at: http://localhost:8080
 * It supports the following databases...
-  * mariadb106 (lts)
+  * mariadb106 (lts, deprecated)
   * mariadb1011 (lts)
+  * mariadb1104 (lts)
 
 ### Mailpit
 _For mimicking an email inbox (ala mailtrap) for local usage._

--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -16,6 +16,17 @@ services:
       - ./proxy_increase.conf:/etc/nginx/proxy.conf
     networks:
       - st-internal
+  mariadb1104:
+    image: mariadb:11.4
+    container_name: sourcetoad_mariadb1104
+    ports:
+      - "33114:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=mariadb_user
+      - MYSQL_PASSWORD=mariadb_pass
+    networks:
+      - st-internal
   mariadb1011:
     image: mariadb:10.11
     container_name: sourcetoad_mariadb1011

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - st-internal
     environment:
-      PMA_HOSTS: mariadb1011,mariadb106
+      PMA_HOSTS: mariadb1104,mariadb1011,mariadb106
       PMA_USER: root
       PMA_PASSWORD: root
 networks:


### PR DESCRIPTION
* With most, if not all, projects on 10.11. We can start the deprecation/closure of 10.6 and start an upgrade of projects to 11.4
* https://endoflife.date/mariadb

Timelines
* 10.6 - 06 Jul 2026
* 10.11 -16 Feb 2028
* 11.4 - 29 May 2029

A later PR will actually remove 10.6 once confirmation that no more active projects are still on 10.6.