### PR TITLE
Remove MariaDB 10.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ _For managing MySQL/MariaDB databases visually._
 
 * Viewable at: http://localhost:8080
 * It supports the following databases...
-  * mariadb106 (lts, deprecated)
-  * mariadb1011 (lts)
+  * mariadb1011 (lts, deprecated)
   * mariadb1104 (lts)
 
 ### Mailpit

--- a/docker/data-source-services/docker-compose.yml
+++ b/docker/data-source-services/docker-compose.yml
@@ -38,17 +38,6 @@ services:
       - MYSQL_PASSWORD=mariadb_pass
     networks:
       - st-internal
-  mariadb106:
-    image: mariadb:10.6
-    container_name: sourcetoad_mariadb106
-    ports:
-      - "33106:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=mariadb_user
-      - MYSQL_PASSWORD=mariadb_pass
-    networks:
-      - st-internal
 networks:
   st-internal:
     external: true

--- a/docker/data-source-tools/docker-compose.yml
+++ b/docker/data-source-tools/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - st-internal
     environment:
-      PMA_HOSTS: mariadb1104,mariadb1011,mariadb106
+      PMA_HOSTS: mariadb1104,mariadb1011
       PMA_USER: root
       PMA_PASSWORD: root
 networks:


### PR DESCRIPTION
* We no longer have any active projects on MariaDB 10.6.
* New projects are 11.4 - existing projects are on upgrade paths to 11.4.
* 10.11 is now deprecated - new projects will prefer 11.4.