### PR TITLE
Support env replacement in hop proxy

### DIFF
--- a/bin/_helpers
+++ b/bin/_helpers
@@ -94,6 +94,10 @@ function output_info {
     output_tagged_string "$BG_B" "INFO" "$1"
 }
 
+function output_warning {
+    output_tagged_string "$BG_Y" "INFO" "$1"
+}
+
 export BG_R
 export BG_G
 export BG_Y

--- a/bin/_helpers
+++ b/bin/_helpers
@@ -95,7 +95,7 @@ function output_info {
 }
 
 function output_warning {
-    output_tagged_string "$BG_Y" "INFO" "$1"
+    output_tagged_string "$BG_Y" "WARNING" "$1"
 }
 
 export BG_R

--- a/bin/proxy
+++ b/bin/proxy
@@ -4,6 +4,7 @@
 set -a
 
 if [ -f ".env" ]; then
+    # shellcheck source=/dev/null
     source ".env"
 fi
 

--- a/bin/proxy
+++ b/bin/proxy
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Enable auto-export
+set -a
+
+if [ -f ".env" ]; then
+    source ".env"
+fi
+
+# Disable auto-export
+set +a
+
 HOP_PATH=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 TOOLKIT_PATH=$(dirname "$HOP_PATH")
 
@@ -146,6 +156,16 @@ function pick_one_virtual_host_from_file() {
     local HOST_OPTIONS=()
 
     HOST_STRING=$(sed -nr 's/.*VIRTUAL_HOST=(.*)/\1/p' "$FILE")
+
+    # Trim double quotes from HOST_STRING
+    HOST_STRING=$(echo "$HOST_STRING" | tr -d '"')
+
+    # Pipe HOST_STRING through envsubst if available
+    if command -v envsubst &> /dev/null; then
+        HOST_STRING=$(echo "$HOST_STRING" | envsubst)
+    else
+        >&2 output_warning "envsubst not found. Skipping environment variable substitution."
+    fi
 
     IFS="," read -ra HOSTS <<< "$HOST_STRING"
 


### PR DESCRIPTION
This loads in the `.env` from where `hop proxy` is run if it exists. This allows leveraging `.env` files to do things like make an env to control your desired proxy URL in a single spot.

**.env**
```env
LOCAL_HOST=projectname.docker
PROXY_HOST=someproxy.example.com
```

**docker-compose.override.yml**
```yml
services:
  xxx-code:
    environment:
      - APP_URL=http${PROXY_HOST:+s}://${PROXY_HOST:-$LOCAL_HOST}
  xxx-web:
    environment:
      - VIRTUAL_HOST="${LOCAL_HOST},${PROXY_HOST:-}"
```